### PR TITLE
Deprecated usage of string interpolation

### DIFF
--- a/src/DataBuilder/AddressesDataBuilder.php
+++ b/src/DataBuilder/AddressesDataBuilder.php
@@ -19,7 +19,7 @@ class AddressesDataBuilder implements DataBuilderInterface
         $addresses = ['shipping' => $order->getShippingAddress(), 'billing' => $order->getBillingAddress()];
         foreach ($addresses as $type => $address) {
             if ($address !== null) {
-                $data['payment']["${type}_address"] = $this->getAddressData($address);
+                $data['payment']["{$type}_address"] = $this->getAddressData($address);
             }
         }
 

--- a/src/Payum/Action/CaptureAction.php
+++ b/src/Payum/Action/CaptureAction.php
@@ -55,7 +55,7 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface, Gateway
 
             default:
                 throw new RuntimeException(
-                    "[Alma] Unknown payment page mode '${paymentPageMode}'. Check gateway config"
+                    "[Alma] Unknown payment page mode '{$paymentPageMode}'. Check gateway config"
                 );
         }
     }


### PR DESCRIPTION
### Reason for change

Using ${var} in strings is deprecated, use {$var} instead. The warning is visible during a `clear:cache` for example.

### Code changes

I’ve fix the two usage of string interpolation.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)