### PR TITLE
Fix cart builder for product without image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+v2.1.0
+------
+
+- Fix: CartBuilder fix call to member function getPath() on null
+
 v2.0.0
 ------
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "alma/sylius-payment-plugin",
   "type": "sylius-plugin",
+  "version": "2.1.0",
   "keywords": [
     "alma",
     "buy now pay later",

--- a/src/AlmaSyliusPaymentPlugin.php
+++ b/src/AlmaSyliusPaymentPlugin.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class AlmaSyliusPaymentPlugin extends Bundle
 {
-    const VERSION = "2.0.0";
+    const VERSION = "2.1.0";
 
     use SyliusPluginTrait;
 

--- a/src/DataBuilder/CartDataBuilder.php
+++ b/src/DataBuilder/CartDataBuilder.php
@@ -158,9 +158,9 @@ class CartDataBuilder implements DataBuilderInterface
         /** @var ImageInterface[] $images */
         $images = $subject->getImages();
 
-        if (count($mainPictures) > 0) {
+        if (!empty($mainPictures) && $mainPictures[0] !== null ) {
             $path = $mainPictures[0]->getPath();
-        } elseif (count($images) > 0) {
+        } elseif (!empty($images) && $images[0] !== null) {
             $path = $images[0]->getPath();
         }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[ClickUp task](https://linear.app/almapay/issue/ECOM-2217/investigate-inaccurate-total-cart-amount)

### Code changes

Check if first object in array is null 


### How to test

No test in local 

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->