### PR TITLE
[security] ensure used GH Actions are pinned using SHA.

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Aqua scanner
         uses: docker://aquasec/aqua-scanner

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,10 +15,10 @@ jobs:
         working-directory: .
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f #v2
         with:
           php-version: 8.0
 


### PR DESCRIPTION
PR pins GH Action with Git SHA.

Hashes were obtained by running:
```
git ls-remote git@github.com:actions/checkout.git v4
git ls-remote git@github.com:everlytic/branch-merge 1.1.2
git ls-remote git@github.com:shivammathur/setup-php v2
```